### PR TITLE
The mixt experiment

### DIFF
--- a/src/py2js/transpiler.py
+++ b/src/py2js/transpiler.py
@@ -118,6 +118,9 @@ class JS(object):
         if context:
             _copy_context = context.copy()
             for key in _copy_context.keys():
+                # TODO: review this line
+                if hasattr(_copy_context[key], 'to_html'):
+                    continue
                 if callable(_copy_context[key]):
                     value = context.pop(key)
                     source = inspect.getsource(value)

--- a/src/ryzom/components.py
+++ b/src/ryzom/components.py
@@ -307,6 +307,10 @@ class Component(metaclass=ComponentMetaclass):
                 return False
         return True
 
+    def __call__(self, *content):
+        self.content += content
+        return self
+
     def preparecontent(self):
         '''Set the parent and position of children
 

--- a/src/ryzom/html.py
+++ b/src/ryzom/html.py
@@ -139,3 +139,6 @@ class Html(Component):
         if title := getattr(self, 'title', None):
             self.__dict__['title'] = Title(title)
             self.head.addchild(self.title)
+
+class Raw(Component):
+    pass


### PR DESCRIPTION
I've been experimenting with [mixt](https://github.com/twidi/mixt) (previously pyxl) to use html in python (similar to react)
I like the syntax more, and find it more readable for small and large components, but still rely on ryzom for two ways data-binding, transpilation to js and server-side re-rendering and server-side reactivity.

It has been surprisingly easy to replace `mixt.html` by `ryzom.html`, minus the API difference :
```python
Component(**attrs)(*children) #mist
Component(*children, **attrs) #ryzom
```

A workaround could be to implement a `__call__(*children)` function to ryzom components.
Making this change allows this kind of syntax (allowing infinite composition):
```python
el = Div()(Span()("Click "),A()("here", cls="link", href="/next"),Span()(" to continue"))
```
Which would be the compilation of :
```python
# coding: mixt
el = (<div>
  <span>Click </span>
    <a class="link" href="/next">here</a>
  <span> to continue</span>
</div>)
```

Here are (still simple) real world exemple:
```python
# coding: mixt
from ryzom_django_mdc import html
from .decorator import component

@component(html.Div)
def Container(*content, **context):
    return (<div class="container">
        {*content}
    </div>)
```

```python
# coding: mixt
@html.template('dashboard_instance_detail', App)
class InstanceDetail(html.Div):
    def to_html(self, *content, view, **context):
        obj = view.object
        url = "https://{}.{}".format(obj.subdomain, settings.domain)
        return super().to_html((<div>
            <h2>name: {obj.name}</h2>
            <h3>statuss: {obj.status}</h3>
            <h3>url: <a href="{url}">{obj.subdomain}.{settings.domain}</a></h3>
          </div>),
          view=view, **context
        )
```

We could then attach onclick, etc function like we did and have something that is readable like react (and could help for onboarding and making the techo more popular, (and maybe get some hackernews karma ^^ as an alternerative to phoenix liveview with even more feature, on a more popular language)

PS: I had to make a tough change in the transpiler to make it works, i'm not sure of the impact.

I know that it doesn't really seems shorter nor more readable yet, but I think that it could be helpful on the long run.

Slot support could be a great thing as well, not sure how to implement that